### PR TITLE
Use full URL string for fs_cdn

### DIFF
--- a/src/qcommon/files.cpp
+++ b/src/qcommon/files.cpp
@@ -3587,9 +3587,9 @@ static void FS_Startup(const char *gameName, cb_context_t *after )
     fs_debug = Cvar_Get("fs_debug", "0", 0);
 
 #if EMSCRIPTEN
-	//fs_cdn = Cvar_Get("fs_cdn", "127.0.0.1", CVAR_INIT | CVAR_SERVERINFO); //Auriga: Use 127.0.0.1, nodejs does not like localhost in some cases
-	//fs_cdn = Cvar_Get("fs_cdn", "cdn.tremulo.us", CVAR_INIT | CVAR_SERVERINFO);
-	fs_cdn = Cvar_Get("fs_cdn", "content.tremulous.online:9000", CVAR_INIT | CVAR_SERVERINFO);
+	//fs_cdn = Cvar_Get("fs_cdn", "http://127.0.0.1/assets", CVAR_INIT | CVAR_SERVERINFO); //Auriga: Use 127.0.0.1, nodejs does not like localhost in some cases
+	//fs_cdn = Cvar_Get("fs_cdn", "https://cdn.tremulo.us/base-assets", CVAR_INIT | CVAR_SERVERINFO);
+	fs_cdn = Cvar_Get("fs_cdn", "https://content.tremulous.online/assets", CVAR_INIT | CVAR_SERVERINFO);
 	fs_manifest = Cvar_Get("fs_manifest", "", CVAR_ROM | CVAR_SERVERINFO);
 	fs_completeManifest = Cvar_Get("fs_completeManifest", "", CVAR_ROM);
     Com_Printf("Using content server: %s\n", fs_cdn->string);

--- a/src/sys/sys_common.js
+++ b/src/sys/sys_common.js
@@ -216,7 +216,7 @@ var LibrarySysCommon = {
 		DownloadAsset: function (asset, onprogress, onload) {
 			var root = SYSC.GetCDN();
 			var name = asset.name.replace(/(.+\/|)(.+?)$/, '$1' + asset.checksum + '-$2');
-			var url = 'https://' + root + '/assets/' + name;
+			var url = root + '/' + name;
 
 			SYS.DoXHR(url, {
 				dataType: 'arraybuffer',
@@ -268,7 +268,7 @@ var LibrarySysCommon = {
 			var fs_game = Module.UTF8ToString(_Cvar_VariableString(Module.allocate(intArrayFromString('fs_game'), ALLOC_STACK)));
 			var com_basegame = Module.UTF8ToString(_Cvar_VariableString(Module.allocate(intArrayFromString('com_basegame'), ALLOC_STACK)));
 			var mapname = Module.UTF8ToString(_Cvar_VariableString(Module.allocate(intArrayFromString('mapname'), ALLOC_STACK)));
-			var url = "https://" + fs_cdn + '/assets/manifest.json';
+			var url = fs_cdn + '/manifest.json';
 			console.log("URL:", url);
 			/*function isInstaller(name) {
 				return SYSC.installers.some(function (installer) {

--- a/src/sys/sys_main.cpp
+++ b/src/sys/sys_main.cpp
@@ -666,7 +666,7 @@ void Sys_SigHandler( int signal )
 
 #ifndef DEFAULT_BASEDIR
 # if EMSCRIPTEN
-#  define DEFAULT_BASEDIR "/tremulous"
+#  define DEFAULT_BASEDIR "/tremulous_base"
 # elif __APPLE__
 #  define DEFAULT_BASEDIR Sys_StripAppBundle(Sys_BinaryPath())
 # else


### PR DESCRIPTION
The solution I want to use for https://github.com/justinl1996/tremulous/issues/6 as I've had this problem myself
Note, in your startup options Cvar_Get does not like the // in https://, so you will need to wrap the cvar value in quotes
Something like           '+set', 'fs_cdn', '"http://127.0.0.1:9000/assets"'